### PR TITLE
Improve check for file when adding `@@download` in url.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.18 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Improve check for file when adding `@@download` in url.
+  [laz, boulch]
 
 1.17 (2020-10-06)
 -----------------

--- a/src/imio/prettylink/adapters.py
+++ b/src/imio/prettylink/adapters.py
@@ -131,7 +131,9 @@ class PrettyLinkAdapter(object):
         url = self.context.absolute_url()
         # add @@download to url if necessary, it is the case for dexterity files
         try:
-            if IPrimaryFieldInfo(self.context):
+            primary_field_info = IPrimaryFieldInfo(self.context)
+            primary_field = getattr(self.context, primary_field_info.fieldname)
+            if hasattr(primary_field, 'filename'):
                 url = u'{0}/@@download'.format(url)
         except TypeError:
             pass

--- a/src/imio/prettylink/adapters.py
+++ b/src/imio/prettylink/adapters.py
@@ -5,6 +5,7 @@ from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_unicode
 from zope.i18n import translate
 
@@ -133,7 +134,7 @@ class PrettyLinkAdapter(object):
         try:
             primary_field_info = IPrimaryFieldInfo(self.context)
             primary_field = getattr(self.context, primary_field_info.fieldname)
-            if hasattr(primary_field, 'filename'):
+            if base_hasattr(primary_field, 'filename'):
                 url = u'{0}/@@download'.format(url)
         except TypeError:
             pass


### PR DESCRIPTION
Reasons to check for the primary field this way (can be discussed):
-  we are afraid of checking on field interface (Archetypes >< Dexterity)
- `IPrimaryFieldInfo` doesn't work as is in tests, even with a file content type
