### PR TITLE
feat(GHA): update deprecated version of cache actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pip install -r requirements.txt coverage==5.3.1
       - name: Cache eggs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-eggs
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/

ref: DEVOPS-174